### PR TITLE
Fix Get-WinVersionNumber

### DIFF
--- a/WimWitchFK/Private/WWFunctions.ps1
+++ b/WimWitchFK/Private/WWFunctions.ps1
@@ -5342,32 +5342,23 @@ Function Update-WinReWim {
 #Function to retrieve windows version
 Function Get-WinVersionNumber {
     $buildnum = $null
+    $ver = [System.Version]$WPFSourceWimVerTextBox.text
 
     # Latest 10 Windows 10 version checks
-    switch -Regex ($WPFSourceWimVerTextBox.text) {
-        '10\.0\.19045\.3930' { $buildnum = '22H2' }
-        '10\.0\.19044\.3930' { $buildnum = '21H2' }
-        '10\.0\.19045\.3803' { $buildnum = '22H2' }
-        '10\.0\.19044\.3803' { $buildnum = '21H2' }
-        '10\.0\.19045\.3693' { $buildnum = '22H2' }
-        '10\.0\.19044\.3693' { $buildnum = '21H2' }
-        '10\.0\.19045\.3570' { $buildnum = '22H2' }
-        '10\.0\.19044\.3570' { $buildnum = '21H2' }
-        '10\.0\.19045\.3448' { $buildnum = '22H2' }
-        '10\.0\.19044\.3448' { $buildnum = '21H2' }
+    switch ($ver.Build) {
+        #Win10
+        19044 {$buildnum = '21H2'}
+        19045 {$buildnum = '22H2'}
 
-        # Windows 11 version checks
-        '10\.0\.22631\.3007' { $buildnum = '23H2' }
-        '10\.0\.22621\.3007' { $buildnum = '22H2' }
-        '10\.0\.22631\.2715' { $buildnum = '23H2' }
-        '10\.0\.22621\.2861' { $buildnum = '23H2' }
-        '10\.0\.22000\.2713' { $buildnum = '21H2' }
-        '10\.0\.22621\.2428' { $buildnum = '22H2' }
+        #Win11
+        22000 {$buildnum = '21H2'}
+        22621 {$buildnum = '22H2'}
+        22631 {$buildnum = '23H2'}
 
-        # Add all other specific Windows 11 build checks here...
-        '10\.0\.22621\.2134' { $buildnum = '22H2' }
-        '10\.0\.22000\.2652' { $buildnum = '21H2' }
-        # Continue for all provided Windows 11 builds
+        #Server
+        14393 {$buildnum = '1607'}
+        17763 {$buildnum = '1809'}
+        20348 {$buildnum = '21H2'}
 
         Default { $buildnum = 'Unknown Version' }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Matching logic was fragile and did not include any server versions. This should populate the 'Version' field in the Source WIM tab and allow patching to work.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes part of #26, #27 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

